### PR TITLE
action: increase timeout for docker start

### DIFF
--- a/lib/setup-docker.js
+++ b/lib/setup-docker.js
@@ -177,8 +177,8 @@ while ! /Applications/Docker.app/Contents/Resources/bin/docker system info &>/de
 (( i++ == 0 )) && printf %s '-- Waiting for Docker to finish starting up...' || printf '.'
 command -v docker || echo 'test docker command loop: not found'
 sleep 1
-# wait 180s(3min)
-if [ $i -gt 180 ];then exit 1;sudo /Applications/Docker.app/Contents/MacOS/com.docker.diagnose check;uname -a;system_profiler SPHardwareDataType;echo "::error::-- Wait docker start $i s too long, exit"; exit 1; fi
+# wait 600s(10min)
+if [ $i -gt 600 ];then exit 1;sudo /Applications/Docker.app/Contents/MacOS/com.docker.diagnose check;uname -a;system_profiler SPHardwareDataType;echo "::error::-- Wait docker start $i s too long, exit"; exit 1; fi
 done
 echo "::notice::-- Docker is ready.Wait time is $i s"
 uname -a || true


### PR DESCRIPTION
Increased timeout for docker start from 180s to 600s. Have done it because sometimes 180s is not enough for github macOS runners.